### PR TITLE
Allow Context to take another Context instance in new

### DIFF
--- a/django/template/context.py
+++ b/django/template/context.py
@@ -35,7 +35,9 @@ class BaseContext(object):
     def _reset_dicts(self, value=None):
         builtins = {'True': True, 'False': False, 'None': None}
         self.dicts = [builtins]
-        if value is not None:
+        if isinstance(value, BaseContext):
+            self.dicts += value.dicts[1:]
+        elif value is not None:
             self.dicts.append(value)
 
     def __copy__(self):

--- a/tests/template_tests/test_context.py
+++ b/tests/template_tests/test_context.py
@@ -61,6 +61,19 @@ class ContextTests(TestCase):
             'a': 2, 'b': 4, 'c': 8
         })
 
+    def test_flatten_context_new_context(self):
+        """
+        Context.new with a Context argument should work.
+        """
+        a = Context({'a': 2})
+        b = a.new(Context({'b': 4}))
+        self.assertDictEqual(b.flatten(), {
+            'False': False,
+	    'None': None,
+	    'True': True,
+            'b': 4
+        })
+
     def test_context_comparable(self):
         test_data = {'x': 'y', 'v': 'z', 'd': {'o': object, 'a': 'b'}}
 


### PR DESCRIPTION
Related to https://code.djangoproject.com/ticket/24765. If a
context instance is passed into new the context instance is
appended to dicts. The flatten method fails on instances of Context
because BaseContext#**iter** returns iterates of the dicts.

This change pulls the dicts over Context supplied in new

This should go to 1.9 as well and we should get it pushed upstream
