### PR TITLE
Port PR 2968 renaming use_debug_cursor to force_debug_cursor

### DIFF
--- a/django/db/backends/__init__.py
+++ b/django/db/backends/__init__.py
@@ -39,7 +39,7 @@ class BaseDatabaseWrapper(object):
         self.queries = []
         self.settings_dict = settings_dict
         self.alias = alias
-        self.use_debug_cursor = False
+        self.force_debug_cursor = False
 
         # Savepoint management related attributes
         self.savepoint_state = 0
@@ -84,7 +84,7 @@ class BaseDatabaseWrapper(object):
 
     @property
     def queries_logged(self):
-        return self.use_debug_cursor or settings.DEBUG
+        return self.force_debug_cursor or settings.DEBUG
 
     ##### Backend-specific methods for creating connections and cursors #####
 

--- a/django/test/utils.py
+++ b/django/test/utils.py
@@ -442,15 +442,15 @@ class CaptureQueriesContext(object):
         return self.connection.queries[self.initial_queries:self.final_queries]
 
     def __enter__(self):
-        self.use_debug_cursor = self.connection.use_debug_cursor
-        self.connection.use_debug_cursor = True
+        self.force_debug_cursor = self.connection.force_debug_cursor
+        self.connection.force_debug_cursor = True
         self.initial_queries = len(self.connection.queries)
         self.final_queries = None
         request_started.disconnect(reset_queries)
         return self
 
     def __exit__(self, exc_type, exc_value, traceback):
-        self.connection.use_debug_cursor = self.use_debug_cursor
+        self.connection.force_debug_cursor = self.force_debug_cursor
         request_started.connect(reset_queries)
         if exc_type is not None:
             return


### PR DESCRIPTION
This simply brings over the property rename from future Django. No actual functional change. This is needed for forwards compatibility from 1.7 -> 1.9

Source: https://github.com/django/django/pull/2968/files?diff=unified

cc @csomme @brodie
