### PR TITLE
wrap _populate() in try/finally in case of signal

### DIFF
--- a/django/urls/resolvers.py
+++ b/django/urls/resolvers.py
@@ -282,52 +282,55 @@ class RegexURLResolver(LocaleRegexProvider):
         # thread-local variable.
         if getattr(self._local, 'populating', False):
             return
-        self._local.populating = True
-        lookups = MultiValueDict()
-        namespaces = {}
-        apps = {}
-        language_code = get_language()
-        for pattern in reversed(self.url_patterns):
-            if isinstance(pattern, RegexURLPattern):
-                self._callback_strs.add(pattern.lookup_str)
-            p_pattern = pattern.regex.pattern
-            if p_pattern.startswith('^'):
-                p_pattern = p_pattern[1:]
-            if isinstance(pattern, RegexURLResolver):
-                if pattern.namespace:
-                    namespaces[pattern.namespace] = (p_pattern, pattern)
-                    if pattern.app_name:
-                        apps.setdefault(pattern.app_name, []).append(pattern.namespace)
-                else:
-                    parent_pat = pattern.regex.pattern
-                    for name in pattern.reverse_dict:
-                        for matches, pat, defaults in pattern.reverse_dict.getlist(name):
-                            new_matches = normalize(parent_pat + pat)
-                            lookups.appendlist(
-                                name,
-                                (
-                                    new_matches,
-                                    p_pattern + pat,
-                                    dict(defaults, **pattern.default_kwargs),
+        
+        try:
+            self._local.populating = True
+            lookups = MultiValueDict()
+            namespaces = {}
+            apps = {}
+            language_code = get_language()
+            for pattern in reversed(self.url_patterns):
+                if isinstance(pattern, RegexURLPattern):
+                    self._callback_strs.add(pattern.lookup_str)
+                p_pattern = pattern.regex.pattern
+                if p_pattern.startswith('^'):
+                    p_pattern = p_pattern[1:]
+                if isinstance(pattern, RegexURLResolver):
+                    if pattern.namespace:
+                        namespaces[pattern.namespace] = (p_pattern, pattern)
+                        if pattern.app_name:
+                            apps.setdefault(pattern.app_name, []).append(pattern.namespace)
+                    else:
+                        parent_pat = pattern.regex.pattern
+                        for name in pattern.reverse_dict:
+                            for matches, pat, defaults in pattern.reverse_dict.getlist(name):
+                                new_matches = normalize(parent_pat + pat)
+                                lookups.appendlist(
+                                    name,
+                                    (
+                                        new_matches,
+                                        p_pattern + pat,
+                                        dict(defaults, **pattern.default_kwargs),
+                                    )
                                 )
-                            )
-                    for namespace, (prefix, sub_pattern) in pattern.namespace_dict.items():
-                        namespaces[namespace] = (p_pattern + prefix, sub_pattern)
-                    for app_name, namespace_list in pattern.app_dict.items():
-                        apps.setdefault(app_name, []).extend(namespace_list)
-                if not getattr(pattern._local, 'populating', False):
-                    pattern._populate()
-                self._callback_strs.update(pattern._callback_strs)
-            else:
-                bits = normalize(p_pattern)
-                lookups.appendlist(pattern.callback, (bits, p_pattern, pattern.default_args))
-                if pattern.name is not None:
-                    lookups.appendlist(pattern.name, (bits, p_pattern, pattern.default_args))
-        self._reverse_dict[language_code] = lookups
-        self._namespace_dict[language_code] = namespaces
-        self._app_dict[language_code] = apps
-        self._populated = True
-        self._local.populating = False
+                        for namespace, (prefix, sub_pattern) in pattern.namespace_dict.items():
+                            namespaces[namespace] = (p_pattern + prefix, sub_pattern)
+                        for app_name, namespace_list in pattern.app_dict.items():
+                            apps.setdefault(app_name, []).extend(namespace_list)
+                    if not getattr(pattern._local, 'populating', False):
+                        pattern._populate()
+                    self._callback_strs.update(pattern._callback_strs)
+                else:
+                    bits = normalize(p_pattern)
+                    lookups.appendlist(pattern.callback, (bits, p_pattern, pattern.default_args))
+                    if pattern.name is not None:
+                        lookups.appendlist(pattern.name, (bits, p_pattern, pattern.default_args))
+            self._reverse_dict[language_code] = lookups
+            self._namespace_dict[language_code] = namespaces
+            self._app_dict[language_code] = apps
+            self._populated = True
+        finally:
+            self._local.populating = False
 
     @property
     def reverse_dict(self):


### PR DESCRIPTION
The _populate() method sets a flag to prevent infinite recursion in case a urlconf includes itself. The flag is a threadlocal to avoid race conditions where one thread sets the flag and another checks it, then proceeds to access data that's supposed to be populated (e.g. `_reverse_dict`) but isn't yet.

The potential still exists for a thread to set the threadlocal, then be interrupted by a signal such as SIGALRM ([*ahem*]) and raise before resetting the threadlocal flag. In this scenario, subsequent calls to `_populate()` in the same thread will short-circuit erroneously.

This change handles this potential case by resetting the threadlocal in a `finally` block, which will run before the signal handler.

[1]: https://bitbucket.org/evzijst/interruptingcow